### PR TITLE
Build chain support para

### DIFF
--- a/collator/src/cli.rs
+++ b/collator/src/cli.rs
@@ -15,6 +15,7 @@
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::chain_spec;
+use crate::commands::BuildSpecCmd;
 use sc_cli;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -31,7 +32,10 @@ pub enum Subcommand {
 	ExportGenesisWasm(ExportGenesisWasmCommand),
 
 	/// Build a chain specification.
-	BuildSpec(sc_cli::BuildSpecCmd),
+	BuildSpec(BuildSpecCmd),
+
+	/// Build a chain specification (original version).
+	OriginBuildSpec(sc_cli::BuildSpecCmd),
 
 	/// Validate blocks.
 	CheckBlock(sc_cli::CheckBlockCmd),

--- a/collator/src/command.rs
+++ b/collator/src/command.rs
@@ -147,6 +147,19 @@ pub fn run() -> Result<()> {
 	match &cli.subcommand {
 		Some(Subcommand::BuildSpec(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
+
+			// Ref: https://github.com/paritytech/substrate/blob/master/client/cli/src/config.rs#L475
+			let chain_spec = load_spec(
+				&cmd.shared_params.chain.clone().unwrap_or_default(),
+				cmd.parachain_id.unwrap_or(30).into()
+			)?;
+
+			runner.sync_run(|config| {
+				cmd.run(chain_spec, config.network)
+			})
+		}
+		Some(Subcommand::OriginBuildSpec(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
 			runner.sync_run(|config| cmd.run(config.chain_spec, config.network))
 		}
 		Some(Subcommand::CheckBlock(cmd)) => {

--- a/collator/src/command.rs
+++ b/collator/src/command.rs
@@ -34,7 +34,7 @@ use sc_service::{
 };
 use sp_core::hexdisplay::HexDisplay;
 use sp_runtime::traits::Block as BlockT;
-use std::{io::Write, net::SocketAddr, env };
+use std::{io::Write, net::SocketAddr};
 
 fn load_spec(
 	id: &str,
@@ -84,9 +84,7 @@ impl SubstrateCli for Cli {
 	}
 
 	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-		load_spec(id, self.run.parachain_id.unwrap_or(env::var("PARAID")
-			.expect("expect to set PARAID environment variable").parse::<u32>()
-			.expect("expect to set PARAID as a u32")).into())
+		load_spec(id, self.run.parachain_id.unwrap_or(30).into())
 	}
 
 	fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
@@ -291,9 +289,7 @@ pub fn run() -> Result<()> {
 						.chain(cli.relaychain_args.iter()),
 				);
 
-				let id = ParaId::from(cli.run.parachain_id.or(para_id).unwrap_or(env::var("PARAID")
-					.expect("expect to set PARAID environment variable").parse::<u32>()
-					.expect("expect to set PARAID as a u32")));
+				let id = ParaId::from(cli.run.parachain_id.or(para_id).unwrap_or(30));
 
 				let parachain_account =
 					AccountIdConversion::<polkadot_primitives::v0::AccountId>::into_account(&id);

--- a/collator/src/commands/build_spec_cmd.rs
+++ b/collator/src/commands/build_spec_cmd.rs
@@ -1,0 +1,93 @@
+// This file is part of Substrate.
+
+// Copyright (C) 2018-2021 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use sc_cli::Result;
+use sc_cli::NodeKeyParams;
+use sc_cli::SharedParams;
+use sc_cli::CliConfiguration;
+use log::info;
+use sc_network::config::build_multiaddr;
+use sc_service::{config::{MultiaddrWithPeerId, NetworkConfiguration}, ChainSpec};
+use structopt::StructOpt;
+use std::io::Write;
+
+/// The `build-spec` command used to build a specification.
+/// Cheated from
+#[derive(Debug, StructOpt)]
+pub struct BuildSpecCmd {
+    /// Force raw genesis storage output.
+    #[structopt(long = "raw")]
+    pub raw: bool,
+
+    /// Disable adding the default bootnode to the specification.
+    ///
+    /// By default the `/ip4/127.0.0.1/tcp/30333/p2p/NODE_PEER_ID` bootnode is added to the
+    /// specification when no bootnode exists.
+    #[structopt(long = "disable-default-bootnode")]
+    pub disable_default_bootnode: bool,
+
+    #[allow(missing_docs)]
+    #[structopt(flatten)]
+    pub shared_params: SharedParams,
+
+    #[allow(missing_docs)]
+    #[structopt(flatten)]
+    pub node_key_params: NodeKeyParams,
+
+    /// Id of the parachain this state is for.
+    #[structopt(long)]
+    pub parachain_id: Option<u32>,
+}
+
+impl BuildSpecCmd {
+    /// Run the build-spec command
+    pub fn run(
+        &self,
+        mut spec: Box<dyn ChainSpec>,
+        network_config: NetworkConfiguration,
+    ) -> Result<()> {
+        info!("Building chain spec");
+        let raw_output = self.raw;
+
+        if spec.boot_nodes().is_empty() && !self.disable_default_bootnode {
+            let keys = network_config.node_key.into_keypair()?;
+            let peer_id = keys.public().into_peer_id();
+            let addr = MultiaddrWithPeerId {
+                multiaddr: build_multiaddr![Ip4([127, 0, 0, 1]), Tcp(30333u16)],
+                peer_id,
+            };
+            spec.add_boot_node(addr)
+        }
+
+        let json = sc_service::chain_ops::build_spec(&*spec, raw_output)?;
+        if std::io::stdout().write_all(json.as_bytes()).is_err() {
+            let _ = std::io::stderr().write_all(b"Error writing to stdout\n");
+        }
+        Ok(())
+    }
+}
+
+impl CliConfiguration for BuildSpecCmd {
+    fn shared_params(&self) -> &SharedParams {
+        &self.shared_params
+    }
+
+    fn node_key_params(&self) -> Option<&NodeKeyParams> {
+        Some(&self.node_key_params)
+    }
+}

--- a/collator/src/commands/mod.rs
+++ b/collator/src/commands/mod.rs
@@ -1,0 +1,5 @@
+mod build_spec_cmd;
+
+pub use self::{
+    build_spec_cmd::BuildSpecCmd,
+};

--- a/collator/src/main.rs
+++ b/collator/src/main.rs
@@ -24,6 +24,7 @@ mod chain_spec;
 mod service;
 mod cli;
 mod command;
+mod commands;
 
 fn main() -> sc_cli::Result<()> {
 	command::run()

--- a/pallets/claim/src/mock.rs
+++ b/pallets/claim/src/mock.rs
@@ -55,6 +55,7 @@ impl system::Config for Test {
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
 	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
 }
 
 impl pallet_balances::Config for Test {

--- a/pallets/mining_staking/src/mock.rs
+++ b/pallets/mining_staking/src/mock.rs
@@ -60,6 +60,7 @@ impl system::Config for Test {
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
 	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
 }
 
 impl pallet_balances::Config for Test {

--- a/pallets/phala/src/mock.rs
+++ b/pallets/phala/src/mock.rs
@@ -58,6 +58,7 @@ impl system::Config for Test {
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
 	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
 }
 
 impl pallet_balances::Config for Test {


### PR DESCRIPTION
I really don't like passing `ENV` to CLI, after some research I find a way to add `parachain-id` to `build-spec`